### PR TITLE
re-add cwd to afwdata_clone resource in lsststack::lsstsw

### DIFF
--- a/manifests/lsstsw.pp
+++ b/manifests/lsstsw.pp
@@ -141,7 +141,7 @@ define lsststack::lsstsw(
   exec { 'afwdata_clone':
     command => "git clone -b master ${afwdata_bundle} ${afwdata_clone}",
     path    => ["${lsstsw}/lfs/bin", '/bin', '/usr/bin'],
-#    cwd     => $home,
+    cwd     => $home,
     creates => $afwdata_clone,
     user    => $user,
     timeout => 3600,

--- a/spec/unit/defines/lsstsw_spec.rb
+++ b/spec/unit/defines/lsstsw_spec.rb
@@ -78,6 +78,12 @@ EOS
       end
       it do
         should contain_exec('afwdata_clone').with(
+          :command => "git clone -b master /home/#{name}/afwdata.bundle /home/#{name}/lsstsw/build/afwdata",
+          :path    => ["/home/#{name}/lsstsw/lfs/bin", '/bin', '/usr/bin'],
+          :cwd     => "/home/#{name}",
+          :creates => "/home/#{name}/lsstsw/build/afwdata",
+          :user    => name,
+          :timeout => 3600
         ).that_requires([
           "Exec[deploy]",
           "Wget::Fetch[/home/#{name}/afwdata.bundle]",


### PR DESCRIPTION
The cwd is aparently required for git to operate correctly.