### PR TITLE
add tar to el package list

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -61,6 +61,7 @@ class lsststack::params {
         'patch',
         'perl',
         'readline-devel',
+        'tar', # needed on el6, not part of @core or @base
         'zlib-devel',
         # needed by lua
         'ncurses-devel',

--- a/spec/unit/classes/lsststack_spec.rb
+++ b/spec/unit/classes/lsststack_spec.rb
@@ -22,6 +22,7 @@ describe 'lsststack', :type => :class do
     'patch',
     'perl',
     'readline-devel',
+    'tar', # needed on el6, not part of @core or @base
     'zlib-devel',
     # needed by lua
     'ncurses-devel',


### PR DESCRIPTION
Amazingly, tar is not part of either @core or @base on el6.  It is part
of @core on el7.