### PR TITLE
[DM-4413] Add emacs-nox and tmux packages.

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -43,10 +43,10 @@ class lsststack::params {
 
       $convenience_packages = [
         'screen',
-	'tmux',
+        'tmux',
         'tree',
         'vim',
-	'emacs-nox'
+        'emacs-nox'
       ]
     }
     'RedHat': {
@@ -89,10 +89,10 @@ class lsststack::params {
 
       $convenience_packages = [
         'screen',
-	'tmux',
+        'tmux',
         'tree',
         'vim-enhanced',
-	'emacs-nox'
+        'emacs-nox'
       ]
 
       $devtoolset_packages = $::operatingsystemmajrelease ? {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -43,8 +43,10 @@ class lsststack::params {
 
       $convenience_packages = [
         'screen',
+	'tmux',
         'tree',
         'vim',
+	'emacs-nox'
       ]
     }
     'RedHat': {
@@ -87,8 +89,10 @@ class lsststack::params {
 
       $convenience_packages = [
         'screen',
+	'tmux',
         'tree',
         'vim-enhanced',
+	'emacs-nox'
       ]
 
       $devtoolset_packages = $::operatingsystemmajrelease ? {

--- a/spec/unit/classes/lsststack_spec.rb
+++ b/spec/unit/classes/lsststack_spec.rb
@@ -39,8 +39,10 @@ describe 'lsststack', :type => :class do
   ]}
   let(:el_con) {[
     'screen',
+    'tmux',
     'tree',
     'vim-enhanced',
+    'emacs-nox'
   ]}
   let (:debian_deps) {[
     'make',
@@ -75,8 +77,10 @@ describe 'lsststack', :type => :class do
   ]}
   let (:debian_con) {[
     'screen',
+    'tmux',
     'tree',
     'vim',
+    'emacs-nox'
   ]}
 
   describe 'for osfamily RedHat' do


### PR DESCRIPTION
Add the emacs editor without X and tmux terminal multiplexer to our convenience packages.

emacs-nox package information for [CentOS7 base](http://mirror.centos.org/centos-7/7/os/x86_64/Packages/emacs-nox-24.3-11.el7.x86_64.rpm) and [Ubuntu 14.04 trusty](http://packages.ubuntu.com/trusty/emacs24-nox).

tmux package information for [CentOS7 base](http://mirror.centos.org/centos-7/7/os/x86_64/Packages/tmux-1.8-4.el7.x86_64.rpm) and [Ubuntu 14.04 trusty](http://packages.ubuntu.com/trusty/tmux).

	modified:   manifests/params.pp
	modified:   spec/unit/classes/lsststack_spec.rb