### PR TITLE
newinstall.sh now requires devtoolset-3 on el6

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ lsststack::newinstall { 'lsstsw':
   manage_user  => true,
   manage_group => true,
   stack_path   => undef,
-  source       => 'https://sw.lsstcorp.org/eupspkg/newinstall.sh',
+  source       => 'https://raw.githubusercontent.com/lsst/lsst/master/scripts/newinstall.sh',
   debug        => false,
 }
 ```
@@ -284,7 +284,7 @@ When this parameter is `undef`, the "stack" prefix path is constructed as
 
 ##### `source`
 
-`String` Defaults to 'https://sw.lsstcorp.org/eupspkg/newinstall.sh'
+`String` Defaults to 'https://raw.githubusercontent.com/lsst/lsst/master/scripts/newinstall.sh'
 
 The URL to retrieve the `newinstall.sh` script from.
 

--- a/manifests/newinstall.pp
+++ b/manifests/newinstall.pp
@@ -87,13 +87,17 @@ define lsststack::newinstall(
 
   exec { 'newinstall.sh':
     environment => ["PWD=${real_stack_path}"],
-    command     => 'newinstall.sh -b',
+    command     => 'if grep -q -i "CentOS release 6" /etc/redhat-release; then
+      . /opt/rh/devtoolset-3/enable
+    fi
+    newinstall.sh -b',
     path        => ['/bin', '/usr/bin', $real_stack_path],
     cwd         => $real_stack_path,
     user        => $user,
     logoutput   => true,
     creates     => "${real_stack_path}/loadLSST.bash",
     timeout     => 900,
+    provider    => 'shell',
     require     => File['newinstall.sh'],
   }
 }

--- a/manifests/newinstall.pp
+++ b/manifests/newinstall.pp
@@ -7,7 +7,7 @@ define lsststack::newinstall(
   $manage_group = true,
   $stack_path   = undef,
   $source       = hiera('lsststack::newinstall::source',
-                        'https://sw.lsstcorp.org/eupspkg/newinstall.sh'),
+                        'https://raw.githubusercontent.com/lsst/lsst/master/scripts/newinstall.sh'),
   $debug        = false,
 ) {
   include ::wget

--- a/spec/unit/defines/newinstall_spec.rb
+++ b/spec/unit/defines/newinstall_spec.rb
@@ -38,7 +38,7 @@ describe 'lsststack::newinstall', :type => :define do
       end
       it do
         should contain_wget__fetch('newinstall.sh').with(
-          :source      => 'https://sw.lsstcorp.org/eupspkg/newinstall.sh',
+          :source      => 'https://raw.githubusercontent.com/lsst/lsst/master/scripts/newinstall.sh',
           :destination => "/home/#{name}/stack/newinstall.sh",
           :execuser    => name,
           :timeout     => 60,
@@ -197,12 +197,12 @@ describe 'lsststack::newinstall', :type => :define do
       context '(unset)' do
         it do
           should contain_lsststack__newinstall(name).with(
-            :source => 'https://sw.lsstcorp.org/eupspkg/newinstall.sh'
+            :source => 'https://raw.githubusercontent.com/lsst/lsst/master/scripts/newinstall.sh'
           )
         end
         it do
           should contain_wget__fetch('newinstall.sh').with(
-            :source => 'https://sw.lsstcorp.org/eupspkg/newinstall.sh'
+            :source => 'https://raw.githubusercontent.com/lsst/lsst/master/scripts/newinstall.sh'
           )
         end
       end

--- a/spec/unit/defines/newinstall_spec.rb
+++ b/spec/unit/defines/newinstall_spec.rb
@@ -57,12 +57,13 @@ describe 'lsststack::newinstall', :type => :define do
       it do
         should contain_exec('newinstall.sh').with(
           :environment => ["PWD=/home/#{name}/stack"],
-          :command => 'newinstall.sh -b',
-          :path => ['/bin', '/usr/bin', "/home/#{name}/stack"],
-          :cwd => "/home/#{name}/stack",
-          :user => name,
-          :logoutput => true,
-          :creates => "/home/#{name}/stack/loadLSST.bash"
+          :command     => /newinstall.sh -b/,
+          :path        => ['/bin', '/usr/bin', "/home/#{name}/stack"],
+          :cwd         => "/home/#{name}/stack",
+          :user        => name,
+          :logoutput   => true,
+          :creates     => "/home/#{name}/stack/loadLSST.bash",
+          :provider    => 'shell'
         ).that_requires('File[newinstall.sh]')
       end
     end # default params


### PR DESCRIPTION
The build of sconsUtils will fail without modern c++ support.