### PR TITLE
remove setup of devtoolset-3 on el6

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -50,7 +50,7 @@ class lsststack::params {
       ]
     }
     'RedHat': {
-      $base_packages = [
+      $dependency_packages = [
         'bison',
         'curl',
         'blas',
@@ -94,13 +94,6 @@ class lsststack::params {
         'vim-enhanced',
         'emacs-nox'
       ]
-
-      $devtoolset_packages = $::operatingsystemmajrelease ? {
-        '6'     => ['devtoolset-3-gcc', 'devtoolset-3-gcc-c++'],
-        default => [],
-      }
-
-      $dependency_packages = concat($base_packages, $devtoolset_packages)
     }
     default: { fail() }
   }

--- a/manifests/repos.pp
+++ b/manifests/repos.pp
@@ -5,24 +5,4 @@ class lsststack::repos {
   if $caller_module_name != $module_name {
     fail("Use of private class ${name} by ${caller_module_name}")
   }
-
-  if $::osfamily == 'RedHat' {
-    if $::operatingsystemmajrelease == '6' {
-      $epel = $::operatingsystemmajrelease ? {
-        '6'     => 'epel-6-x86_64',
-        default => undef,
-      }
-
-      yumrepo { "rhscl-devtoolset-3-${epel}":
-        ensure   => 'present',
-        baseurl  => "https://www.softwarecollections.org/repos/rhscl/devtoolset-3/${epel}",
-        descr    => "Devtoolset-3 - ${epel}",
-        enabled  => '1',
-        gpgcheck => '0',
-      }
-
-      Yumrepo["rhscl-devtoolset-3-${epel}"] -> Package<| provider == 'yum' |>
-    }
-  }
-
 }

--- a/spec/unit/classes/lsststack_spec.rb
+++ b/spec/unit/classes/lsststack_spec.rb
@@ -96,20 +96,10 @@ describe 'lsststack', :type => :class do
         context 'operatingsystemmajrelease => 6' do
           before { facts[:operatingsystemmajrelease] = '6' }
           it { el_deps.each { |pkg| should contain_package(pkg) } }
-          it do
-            ['devtoolset-3-gcc', 'devtoolset-3-gcc-c++'].each do |pkg|
-              should contain_package(pkg)
-            end
-          end
         end
         context 'operatingsystemmajrelease => 7' do
           before { facts[:operatingsystemmajrelease] = '7' }
           it { el_deps.each { |pkg| should contain_package(pkg) } }
-          it do
-            ['devtoolset-3-gcc', 'devtoolset-3-gcc-c++'].each do |pkg|
-              should_not contain_package(pkg)
-            end
-          end
         end
       end
 
@@ -132,15 +122,8 @@ describe 'lsststack', :type => :class do
       context 'true' do
         let(:params) {{ :manage_repos => true }}
 
-        context 'operatingsystemmajrelease => 6' do
-          before { facts[:operatingsystemmajrelease] = '6' }
-          it { should contain_yumrepo('rhscl-devtoolset-3-epel-6-x86_64') }
-        end
-        context 'operatingsystemmajrelease => 7' do
-          before { facts[:operatingsystemmajrelease] = '7' }
-          it { should_not contain_yumrepo('rhscl-devtoolset-3-epel-6-x86_64') }
-          it { should_not contain_yumrepo('rhscl-devtoolset-3-epel-7-x86_64') }
-        end
+        # class is empty after refactoring
+        it { should contain_class('lsststack::repos') }
       end
 
       context 'false' do


### PR DESCRIPTION
We should not hard-wire the compiler to be used at this level, it
complicates testing with different build tool chains.